### PR TITLE
[ruby] Ignore lines with non-utf8 chars

### DIFF
--- a/scripts/run-latex.rb
+++ b/scripts/run-latex.rb
@@ -133,12 +133,18 @@ def main()
   citation_undef  = false
 
   IO.foreach(latex_out) do |line|
-    case line
-      when /Fatal error occurred/                  then exit(1)
-      when /Rerun to get cross-references/         then unresolved_xref = true
-      when /There were multiply-defined labels/    then labels_multidef = true
-      when /LaTeX Warning: Reference .* undefined/ then label_undef     = true
-      when /LaTeX Warning: Citation .* undefined/  then citation_undef  = true
+    begin
+      case line
+        when /Fatal error occurred/                  then exit(1)
+        when /Rerun to get cross-references/         then unresolved_xref = true
+        when /There were multiply-defined labels/    then labels_multidef = true
+        when /LaTeX Warning: Reference .* undefined/ then label_undef     = true
+        when /LaTeX Warning: Citation .* undefined/  then citation_undef  = true
+      end
+    rescue ArgumentError
+      # Handle ArgumentError exception when the pdflatex output contains
+      # non-UTF8 characters. If so we assume the current line does not
+      # match any of the given strings and do nothing.
     end
   end
 
@@ -252,11 +258,17 @@ def main()
     citation_undef  = false
 
     IO.foreach(latex_out) do |line|
-      case line
-        when /Fatal error occurred/                  then exit(1)
-        when /There were multiply-defined labels/    then labels_multidef = true
-        when /.* Warning: Reference .* undefined/ then label_undef     = true
-        when /.* Warning: Citation .* undefined/  then citation_undef  = true
+      begin
+        case line
+          when /Fatal error occurred/               then exit(1)
+          when /There were multiply-defined labels/ then labels_multidef = true
+          when /.* Warning: Reference .* undefined/ then label_undef     = true
+          when /.* Warning: Citation .* undefined/  then citation_undef  = true
+        end
+      rescue ArgumentError
+        # Handle ArgumentError exception when the pdflatex output contains
+        # non-UTF8 characters. If so we assume the current line does not
+        # match any of the given strings and do nothing.
       end
     end
 
@@ -279,12 +291,18 @@ def main()
     citation_undef  = false
 
     IO.foreach(latex_out) do |line|
-      case line
-        when /Fatal error occurred/                  then exit(1)
-        when /Rerun to get cross-references/         then unresolved_xref = true
-        when /There were multiply-defined labels/    then labels_multidef = true
-        when /.* Warning: Reference .* undefined/ then label_undef     = true
-        when /.* Warning: Citation .* undefined/  then citation_undef  = true
+      begin
+        case line
+          when /Fatal error occurred/               then exit(1)
+          when /Rerun to get cross-references/      then unresolved_xref = true
+          when /There were multiply-defined labels/ then labels_multidef = true
+          when /.* Warning: Reference .* undefined/ then label_undef     = true
+          when /.* Warning: Citation .* undefined/  then citation_undef  = true
+        end
+      rescue ArgumentError
+        # Handle ArgumentError exception when the pdflatex output contains
+        # non-UTF8 characters. If so we assume the current line does not
+        # match any of the given strings and do nothing.
       end
     end
 


### PR DESCRIPTION
Ran into an issue where pdflatex produces outputs like this:

```
Overfull \hbox (3.91583pt too wide) in paragraph at lines 293--293
 \T1/LinuxLibertineT-TLF/b/it/10 CCS Con-cepts: \TS1/LinuxLibertineT-TLF/m/n/10
 <88> \T1/LinuxLibertineT-TLF/b/n/10 Hard-ware $\LMS/ntxsy/m/n/10 !$ \T1/LinuxLibe
rtineT-TLF/b/n/10 Hard-ware de-scrip-tion lan-
```

<88> is a non-utf8 character and the Ruby latex launcher cannot proceed (throws an exception saying `../scripts/run-latex.rb:262:in ===: invalid byte sequence in UTF-8 (ArgumentError)`.

This PR ignores such lines in the latex output